### PR TITLE
Refactoring Actions and Feedbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "riedel-mediornet",
-	"version": "1.1.4",
+	"version": "1.2.0",
 	"main": "dist/index.js",
 	"scripts": {
 		"prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "riedel-mediornet",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"main": "dist/index.js",
 	"scripts": {
 		"prepare": "husky install",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7,7 +7,7 @@ import {
 import { DeviceConfig } from './config'
 import { FeedbackId } from './feedback'
 import { matrixnames, DeviceState } from './state'
-import { getInputChoices } from './choices'
+import { getChoices } from './choices'
 import { updateSelectedTargetVariables } from './variables'
 import { EmberClient } from 'node-emberplus/lib/client/ember-client'
 import { QualifiedMatrix } from 'node-emberplus/lib/common/matrix/qualified-matrix'
@@ -16,16 +16,9 @@ export enum ActionId {
   Take = 'take',
   Clear = 'clear',
   Undo = 'undo',
-  SetSourceVideo = 'select_source_video',
-  SetTargetVideo = 'select_target_video',
-  SetSourceAudio = 'select_source_audio',
-  SetTargetAudio = 'select_target_audio',
-  SetSourceData = 'select_source_data',
-  SetTargetData = 'select_target_data',
-  SetSourceMChAudio = 'select_source_multichannelaudio',
-  SetTargetMChAudio = 'select_target_multichannelaudio',
-  SetSourceGPIO = 'select_source_gpio',
-  SetTargetGPIO = 'select_target_gpio',
+  SetSource = 'select_source',
+  SetTarget = 'select_target',
+  SetMatrix = 'select_matrix',
 }
 
 /**
@@ -48,7 +41,7 @@ const doMatrixActionFunction = function(
         .getElementByPathAsync(state.matrices[state.selected.matrix].path)
         .then((node) => {
           if (node && node instanceof QualifiedMatrix) {
-            self.log('debug', 'Got node on ' + state.matrices[state.selected.matrix].label)
+            //self.log('debug', 'Got node on ' + state.matrices[state.selected.matrix].label)
             const target = state.selected.target
             const sources = [state.selected.source]
             emberClient
@@ -72,26 +65,11 @@ const doMatrixActionFunction = function(
           if (config.take_reset) state.selected.matrix = state.selected.source = state.selected.target = -1
 
           self.checkFeedbacks(
-            FeedbackId.SelectedTargetVideo,
-            FeedbackId.SelectedTargetAudio,
-            FeedbackId.SelectedTargetData,
-            FeedbackId.SelectedTargetMultiChannelAudio,
-            FeedbackId.SelectedTargetGPIO,
-            FeedbackId.TakeTallySourceVideo,
-            FeedbackId.TakeTallySourceAudio,
-            FeedbackId.TakeTallySourceData,
-            FeedbackId.TakeTallySourceMultiChannelAudio,
-            FeedbackId.TakeTallySourceGPIO,
-            FeedbackId.SelectedSourceVideo,
-            FeedbackId.SelectedSourceAudio,
-            FeedbackId.SelectedSourceData,
-            FeedbackId.SelectedSourceMultiChannelAudio,
-            FeedbackId.SelectedSourceGPIO,
-            FeedbackId.RoutingTallyVideo,
-            FeedbackId.RoutingTallyAudio,
-            FeedbackId.RoutingTallyData,
-            FeedbackId.RoutingTallyMultiChannelAudio,
-            FeedbackId.RoutingTallyGPIO,
+            FeedbackId.SelectedTarget,
+            FeedbackId.TakeTallySource,
+            FeedbackId.SelectedSource,
+            FeedbackId.RoutingTally,
+            FeedbackId.SelectedMatrix,
             FeedbackId.Take,
             FeedbackId.Clear,
             FeedbackId.Undo
@@ -138,26 +116,11 @@ const doTake =
 const doClear = (self: InstanceBase<DeviceConfig>, state: DeviceState) => (): void => {
   state.selected.matrix = state.selected.source = state.selected.target = -1
   self.checkFeedbacks(
-    FeedbackId.SelectedTargetVideo,
-    FeedbackId.SelectedTargetAudio,
-    FeedbackId.SelectedTargetData,
-    FeedbackId.SelectedTargetMultiChannelAudio,
-    FeedbackId.SelectedTargetGPIO,
-    FeedbackId.TakeTallySourceVideo,
-    FeedbackId.TakeTallySourceAudio,
-    FeedbackId.TakeTallySourceData,
-    FeedbackId.TakeTallySourceMultiChannelAudio,
-    FeedbackId.TakeTallySourceGPIO,
-    FeedbackId.SelectedSourceVideo,
-    FeedbackId.SelectedSourceAudio,
-    FeedbackId.SelectedSourceData,
-    FeedbackId.SelectedSourceMultiChannelAudio,
-    FeedbackId.SelectedSourceGPIO,
-    FeedbackId.RoutingTallyVideo,
-    FeedbackId.RoutingTallyAudio,
-    FeedbackId.RoutingTallyData,
-    FeedbackId.RoutingTallyMultiChannelAudio,
-    FeedbackId.RoutingTallyGPIO,
+    FeedbackId.SelectedTarget,
+    FeedbackId.TakeTallySource,
+    FeedbackId.SelectedSource,
+    FeedbackId.RoutingTally,
+    FeedbackId.SelectedMatrix,
     FeedbackId.Take,
     FeedbackId.Clear,
     FeedbackId.Undo
@@ -173,26 +136,11 @@ const doUndo = (self: InstanceBase<DeviceConfig>, emberClient: EmberClient,
     state.selected.source = selOut.fallback.pop() ?? -1
     doMatrixActionFunction(self, emberClient, config, state)
     self.checkFeedbacks(
-      FeedbackId.SelectedTargetVideo,
-      FeedbackId.SelectedTargetAudio,
-      FeedbackId.SelectedTargetData,
-      FeedbackId.SelectedTargetMultiChannelAudio,
-      FeedbackId.SelectedTargetGPIO,
-      FeedbackId.TakeTallySourceVideo,
-      FeedbackId.TakeTallySourceAudio,
-      FeedbackId.TakeTallySourceData,
-      FeedbackId.TakeTallySourceMultiChannelAudio,
-      FeedbackId.TakeTallySourceGPIO,
-      FeedbackId.SelectedSourceVideo,
-      FeedbackId.SelectedSourceAudio,
-      FeedbackId.SelectedSourceData,
-      FeedbackId.SelectedSourceMultiChannelAudio,
-      FeedbackId.SelectedSourceGPIO,
-      FeedbackId.RoutingTallyVideo,
-      FeedbackId.RoutingTallyAudio,
-      FeedbackId.RoutingTallyData,
-      FeedbackId.RoutingTallyMultiChannelAudio,
-      FeedbackId.RoutingTallyGPIO,
+      FeedbackId.SelectedTarget,
+      FeedbackId.TakeTallySource,
+      FeedbackId.SelectedSource,
+      FeedbackId.RoutingTally,
+      FeedbackId.SelectedMatrix,
       FeedbackId.Take,
       FeedbackId.Clear,
       FeedbackId.Undo
@@ -215,45 +163,44 @@ const setSelectedSource =
     emberClient: EmberClient,
     config: DeviceConfig,
     state: DeviceState,
-    matrix: number
   ) =>
     (action: CompanionActionEvent): void => {
       let check_continue = false
-      if (action.options['source'] === 'next' || action.options['source'] === 'previous') {
 
-        let tempList = state.matrices[state.selected.matrix].inputList
-        let index = tempList.findIndex((value) => value == state.selected.source)
+      if (Boolean(action.options['next_previous_action'])) {
+        if (action.options['next_previous'] === 'next' || action.options['next_previous'] === 'previous') {
+          let tempList = state.matrices[state.selected.matrix].inputList
+          let index = tempList.findIndex((value) => value == state.selected.source)
 
-        if (state.selected.source == -1) state.selected.source = tempList[0]
-        else if (index < tempList.length - 1 && action.options['source'] === 'next') state.selected.source = tempList[index + 1]
-        else if (0 < index && action.options['source'] === 'previous') state.selected.source = tempList[index - 1]
+          if (state.selected.source == -1) state.selected.source = tempList[0]
+          else if (index < tempList.length - 1 && action.options['next_previous'] === 'next') state.selected.source = tempList[index + 1]
+          else if (0 < index && action.options['next_previous'] === 'previous') state.selected.source = tempList[index - 1]
 
-        check_continue = true
-      } else if (action.options['source'] != -1 && matrix == state.selected.matrix) {
-        state.selected.source = Number(action.options['source'])
-        self.log('debug', 'Take is: ' + config.take)
-        if (config.take || action.options['do_take']) doMatrixActionFunction(self, emberClient, config, state)
-        check_continue = true
+
+          check_continue = true
+        }
+      } else {
+        let matrix = Number(action.options['matrix'])
+        let source = Number(action.options[`source_${matrix}`])
+        if (!Number.isNaN(matrix) && !Number.isNaN(source) && matrix == state.selected.matrix) {
+          state.selected.source = source
+          self.log('debug', 'Take is: ' + config.take)
+          if (config.take || action.options['do_take']) doMatrixActionFunction(self, emberClient, config, state)
+          check_continue = true
+        }
       }
+
       if (check_continue) {
         self.checkFeedbacks(
-          FeedbackId.SelectedSourceVideo,
-          FeedbackId.SelectedSourceAudio,
-          FeedbackId.SelectedSourceData,
-          FeedbackId.SelectedSourceMultiChannelAudio,
-          FeedbackId.SelectedSourceGPIO,
-          FeedbackId.RoutingTallyVideo,
-          FeedbackId.RoutingTallyAudio,
-          FeedbackId.RoutingTallyData,
-          FeedbackId.RoutingTallyMultiChannelAudio,
-          FeedbackId.RoutingTallyGPIO,
+          FeedbackId.SelectedSource,
+          FeedbackId.RoutingTally,
           FeedbackId.Take,
           FeedbackId.Clear
         )
         updateSelectedTargetVariables(self, state)
         self.log(
           'debug',
-          'setSelectedSource: ' + action.options['source'] + ' on Matrix: ' + state.matrices[matrix].label
+          'setSelectedSource: ' + state.selected.source + ' on Matrix: ' + state.matrices[state.selected.matrix].label
         )
       }
     }
@@ -265,53 +212,88 @@ const setSelectedSource =
  * @param matrix number of the wanted matrix
  */
 const setSelectedTarget =
-  (self: InstanceBase<DeviceConfig>, state: DeviceState, matrix: number) =>
+  (self: InstanceBase<DeviceConfig>, state: DeviceState) =>
     (action: CompanionActionEvent): void => {
-      if (action.options['target'] === 'next' || action.options['target'] === 'previous') {
-        let tempList = state.matrices[state.selected.matrix].outputList
-        let index = tempList.findIndex((value) => value == state.selected.target)
+      if (Boolean(action.options['next_previous_action'])) {
+        if (action.options['next_previous'] === 'next' || action.options['next_previous'] === 'previous') {
+          let tempList = state.matrices[state.selected.matrix].outputList
+          let index = tempList.findIndex((value) => value == state.selected.target)
 
-        if (state.selected.target == -1) state.selected.target = tempList[0]
-        else if (index < tempList.length - 1 && action.options['target'] === 'next') state.selected.target = tempList[index + 1]
-        else if (0 < index && action.options['target'] === 'previous') state.selected.target = tempList[index - 1]
+          if (state.selected.target == -1) state.selected.target = tempList[0]
+          else if (index < tempList.length - 1 && action.options['next_previous'] === 'next') state.selected.target = tempList[index + 1]
+          else if (0 < index && action.options['next_previous'] === 'previous') state.selected.target = tempList[index - 1]
 
 
-        state.selected.source =  Number(state.matrices[matrix].outputs.get(state.selected.target)?.route)
-        if (Number.isNaN(state.selected.source)) state.selected.source = tempList[0]
-
-      } else if (action.options['target'] != -1) {
-        state.selected.target = Number(action.options['target'])
-        state.selected.matrix = matrix
-        state.selected.source = Number(state.matrices[matrix].outputs.get(Number(action.options['target']))?.route)
+          state.selected.source = Number(state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route)
+          if (Number.isNaN(state.selected.source)) state.selected.source = tempList[0]
+        }
+      } else {
+        let matrix = Number(action.options['matrix'])
+        let target = action.options[`target_${matrix}`]
+        if (!Number.isNaN(matrix)) {
+          if (target != -1) {
+            state.selected.target = Number(target)
+            state.selected.matrix = matrix
+            state.selected.source = Number(state.matrices[matrix].outputs.get(Number(target))?.route)
+          }
+        }
       }
+
       self.checkFeedbacks(
-        FeedbackId.SelectedTargetVideo,
-        FeedbackId.SelectedTargetAudio,
-        FeedbackId.SelectedTargetData,
-        FeedbackId.SelectedTargetMultiChannelAudio,
-        FeedbackId.SelectedTargetGPIO,
-        FeedbackId.TakeTallySourceVideo,
-        FeedbackId.TakeTallySourceAudio,
-        FeedbackId.TakeTallySourceData,
-        FeedbackId.TakeTallySourceMultiChannelAudio,
-        FeedbackId.TakeTallySourceGPIO,
-        FeedbackId.SelectedSourceVideo,
-        FeedbackId.SelectedSourceAudio,
-        FeedbackId.SelectedSourceData,
-        FeedbackId.SelectedSourceMultiChannelAudio,
-        FeedbackId.SelectedSourceGPIO,
-        FeedbackId.RoutingTallyVideo,
-        FeedbackId.RoutingTallyAudio,
-        FeedbackId.RoutingTallyData,
-        FeedbackId.RoutingTallyMultiChannelAudio,
-        FeedbackId.RoutingTallyGPIO,
+        FeedbackId.SelectedTarget,
+        FeedbackId.TakeTallySource,
+        FeedbackId.SelectedSource,
+        FeedbackId.RoutingTally,
+        FeedbackId.SelectedMatrix,
         FeedbackId.Take,
         FeedbackId.Clear,
         FeedbackId.Undo
       )
       updateSelectedTargetVariables(self, state)
-      self.log('debug', 'setSelectedTarget: ' + action.options['target'] + ' on Matrix: ' + state.matrices[matrix].label)
+      self.log('debug', 'setSelectedTarget: ' + state.selected.target + ' on Matrix: ' + state.matrices[state.selected.matrix].label)
+
     }
+
+/**
+ * Selects a source on a specific matrix.
+ * When Auto-Take is enabled the source is routed to the selected target.
+ * @param self reference to the BaseInstance
+ * @param emberClient reference to the emberClient
+ * @param config reference to the config of the module
+ * @param state reference to the state of the module
+ * @param matrix number of the wanted matrix
+ */
+const setSelectedMatrix =
+  (
+    self: InstanceBase<DeviceConfig>,
+    state: DeviceState
+  ) =>
+    (action: CompanionActionEvent): void => {
+      let matrix = Number(action.options['matrix'])
+      if (!Number.isNaN(matrix)) {
+        state.selected.matrix = matrix
+        let tempList = state.matrices[state.selected.matrix].outputList
+        state.selected.target = tempList[0]
+        state.selected.source = Number(state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route)
+        self.checkFeedbacks(
+          FeedbackId.SelectedTarget,
+          FeedbackId.TakeTallySource,
+          FeedbackId.SelectedSource,
+          FeedbackId.RoutingTally,
+          FeedbackId.SelectedMatrix,
+          FeedbackId.Take,
+          FeedbackId.Clear,
+          FeedbackId.Undo
+        )
+        updateSelectedTargetVariables(self, state)
+      }
+      self.log(
+        'debug',
+        'setSelectedMatrix: ' + state.matrices[matrix].label
+      )
+
+    }
+
 
 /**
  * Returns all implemented actions.
@@ -327,7 +309,7 @@ export function GetActionsList(
   config: DeviceConfig,
   state: DeviceState
 ): CompanionActionDefinitions {
-  const { inputChoices, outputChoices } = getInputChoices(state)
+  const { inputChoices, outputChoices, matrixChoices, nextPreviousChoices } = getChoices(state)
 
   const actions: { [id in ActionId]: CompanionActionDefinition | undefined } = {
     [ActionId.Take]: {
@@ -345,191 +327,207 @@ export function GetActionsList(
       options: [],
       callback: doUndo(self, emberClient, config, state)
     },
-    [ActionId.SetSourceVideo]: {
-      name: 'Select Video Source',
+    [ActionId.SetSource]: {
+      name: 'Select Source',
+      description: 'Select a source of a matrix or select next or previous source of currently selected matrix.',
       options: [
         {
+          id: 'next_previous_action',
+          type: 'checkbox',
+          label: 'NEXT/PREVIOUS Action',
+          default: false
+        },
+        {
+          id: 'next_previous',
           type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.video]
+          label: 'Next or Previous',
+          default: 'next',
+          choices: nextPreviousChoices,
+          isVisible: (options) => {
+            return (options['next_previous_action'] == true)
+          }
         },
         {
           type: 'checkbox',
           label: 'Direct Take',
           id: 'do_take',
           default: false,
-          isVisible: (options): boolean => {
-            return !(options['source'] === 'next' || options['source'] === 'previous')
+          isVisible: (options) => {
+            return (options['next_previous_action'] == false)
           }
+        },
+        {
+          type: 'dropdown',
+          label: 'Matrix',
+          id: 'matrix',
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: matrixChoices,
+          isVisible: (options) => {
+            return (options['next_previous_action'] == false)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.video].label} Source`,
+          id: `source_${matrixnames.video}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.video],
+          isVisible: (options) => {
+            return (options['next_previous_action'] == false && options['matrix'] == 0)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.audio].label} Target`,
+          id: `source_${matrixnames.audio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.audio],
+          isVisible: options => {
+            return (options['next_previous_action'] == false && options['matrix'] == 1)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.data].label} Target`,
+          id: `source_${matrixnames.data}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.data],
+          isVisible: options => {
+            return (options['next_previous_action'] == false && options['matrix'] == 2)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.multichannelaudio].label} Target`,
+          id: `source_${matrixnames.multichannelaudio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.multichannelaudio],
+          isVisible: options => {
+            return (options['next_previous_action'] == false && options['matrix'] == 3)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.gpio].label} Target`,
+          id: `source_${matrixnames.gpio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.gpio],
+          isVisible: options => {
+            return (options['next_previous_action'] == false && options['matrix'] == 4)
+          }
+        }
+      ],
+      callback: setSelectedSource(self, emberClient, config, state)
+    },
+    [ActionId.SetTarget]: {
+      name: 'Select Target',
+      options: [
+        {
+          id: 'next_previous_action',
+          type: 'checkbox',
+          label: 'NEXT/PREVIOUS Action',
+          default: false
+        },
+        {
+          id: 'next_previous',
+          type: 'dropdown',
+          label: 'Next or Previous',
+          default: 'next',
+          choices: nextPreviousChoices,
+          isVisible: (options) => {
+            return (options['next_previous_action'] == true)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: 'Matrix',
+          id: 'matrix',
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: matrixChoices,
+          isVisible: (options) => {
+            return (options['next_previous_action'] == false)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.video].label} Target`,
+          id: `target_${matrixnames.video}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.video],
+          isVisible: (options) => {
+            return (options['next_previous_action'] == false && options['matrix'] == 0)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.audio].label} Target`,
+          id: `target_${matrixnames.audio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.audio],
+          isVisible: options => {
+            return (options['next_previous_action'] == false && options['matrix'] == 1)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.data].label} Target`,
+          id: `target_${matrixnames.data}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.data],
+          isVisible: options => {
+            return (options['next_previous_action'] == false && options['matrix'] == 2)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.multichannelaudio].label} Target`,
+          id: `target_${matrixnames.multichannelaudio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.multichannelaudio],
+          isVisible: options => {
+            return (options['next_previous_action'] == false && options['matrix'] == 3)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.gpio].label} Target`,
+          id: `target_${matrixnames.gpio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.gpio],
+          isVisible: options => {
+            return (options['next_previous_action'] == false && options['matrix'] == 4)
+          }
+        }
+      ],
+      callback: setSelectedTarget(self, state)
+    },
 
-        }
-      ],
-      callback: setSelectedSource(self, emberClient, config, state, matrixnames.video)
-    },
-    [ActionId.SetTargetVideo]: {
-      name: 'Select Video Target',
+    [ActionId.SetMatrix]: {
+      name: 'Select Matrix',
+      description: 'Choose a matrix. This way you can use the NEXT and PREVIOUS Actions to select targets and sources.',
       options: [
         {
           type: 'dropdown',
-          label: 'Value',
-          id: 'target',
+          label: 'Matrix',
+          id: 'matrix',
           default: 0,
           minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.video]
+          choices: matrixChoices
         }
       ],
-      callback: setSelectedTarget(self, state, matrixnames.video)
-    },
-    [ActionId.SetSourceAudio]: {
-      name: 'Select Audio Source',
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.audio]
-        },
-        {
-          type: 'checkbox',
-          label: 'Direct Take',
-          id: 'do_take',
-          default: false,
-          isVisible: (options): boolean => {
-            return !(options['source'] === 'next' || options['source'] === 'previous')
-          }
-        }
-      ],
-      callback: setSelectedSource(self, emberClient, config, state, matrixnames.audio)
-    },
-    [ActionId.SetTargetAudio]: {
-      name: 'Select Audio Target',
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'target',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.audio]
-        }
-      ],
-      callback: setSelectedTarget(self, state, matrixnames.audio)
-    },
-    [ActionId.SetSourceData]: {
-      name: 'Select Data Source',
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.data]
-        },
-        {
-          type: 'checkbox',
-          label: 'Direct Take',
-          id: 'do_take',
-          default: false,
-          isVisible: (options): boolean => {
-            return !(options['source'] === 'next' || options['source'] === 'previous')
-          }
-        }
-      ],
-      callback: setSelectedSource(self, emberClient, config, state, matrixnames.data)
-    },
-    [ActionId.SetTargetData]: {
-      name: 'Select Data Target',
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'target',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.data]
-        }
-      ],
-      callback: setSelectedTarget(self, state, matrixnames.data)
-    },
-    [ActionId.SetSourceMChAudio]: {
-      name: 'Select MultiChannelAudio Source',
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.multichannelaudio]
-        },
-        {
-          type: 'checkbox',
-          label: 'Direct Take',
-          id: 'do_take',
-          default: false,
-          isVisible: (options): boolean => {
-            return !(options['source'] === 'next' || options['source'] === 'previous')
-          }
-        }
-      ],
-      callback: setSelectedSource(self, emberClient, config, state, matrixnames.multichannelaudio)
-    },
-    [ActionId.SetTargetMChAudio]: {
-      name: 'Select MultiChannelAudio Target',
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'target',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.multichannelaudio]
-        }
-      ],
-      callback: setSelectedTarget(self, state, matrixnames.multichannelaudio)
-    },
-    [ActionId.SetSourceGPIO]: {
-      name: 'Select GPI Source',
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.gpio]
-        },
-        {
-          type: 'checkbox',
-          label: 'Direct Take',
-          id: 'do_take',
-          default: false,
-          isVisible: (options): boolean => {
-            return !(options['source'] === 'next' || options['source'] === 'previous')
-          }
-        }
-      ],
-      callback: setSelectedSource(self, emberClient, config, state, matrixnames.gpio)
-    },
-    [ActionId.SetTargetGPIO]: {
-      name: 'Select GPO Target',
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'target',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.gpio]
-        }
-      ],
-      callback: setSelectedTarget(self, state, matrixnames.gpio)
+      callback: setSelectedMatrix(self, state)
     }
   }
 

--- a/src/choices.ts
+++ b/src/choices.ts
@@ -4,23 +4,28 @@ import type { DeviceState } from './state'
 export interface InputChoicesResult {
   inputChoices: DropdownChoice[][]
   outputChoices: DropdownChoice[][]
+  matrixChoices: DropdownChoice[]
+  nextPreviousChoices: DropdownChoice[]
 }
 
 /**
  * Returns InputChoices for Actions and Feedbacks.
  * @param state reference to the BaseInstance
  */
-export function getInputChoices(state: DeviceState): InputChoicesResult {
+export function getChoices(state: DeviceState): InputChoicesResult {
   const result: InputChoicesResult = {
     inputChoices: [],
-    outputChoices: []
+    outputChoices: [],
+    matrixChoices: [],
+    nextPreviousChoices: []
   }
+  result.nextPreviousChoices.push({id: 'next', label: 'NEXT'}, {id: 'previous', label: 'PREVIOUS'})
+
   for (let i = 0; i < state.matrices.length; i++) {
     result.inputChoices[i] = []
     result.outputChoices[i] = []
+    result.matrixChoices[i] = {id: i, label: state.matrices[i].label}
 
-    result.inputChoices[i].push({id: 'next', label: 'NEXT'}, {id: 'previous', label: 'PREVIOUS'})
-    result.outputChoices[i].push({id: 'next', label: 'NEXT'}, {id: 'previous', label: 'PREVIOUS'})
 
     state.iterateInputs(i).forEach((value, key) => {
         if (value.active) {

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -6,33 +6,18 @@ import {
 } from '@companion-module/base'
 import { DeviceConfig } from './config'
 import { matrixnames, DeviceState } from './state'
-import { getInputChoices } from './choices'
+import { getChoices } from './choices'
 import { EmberClient } from 'node-emberplus/lib/client/ember-client'
 
 export enum FeedbackId {
   Take = 'take',
   Clear = 'clear',
   Undo = 'undo',
-  SelectedSourceVideo = 'selected_source_video',
-  SelectedSourceAudio = 'selected_source_audio',
-  SelectedSourceData = 'selected_source_data',
-  SelectedSourceMultiChannelAudio = 'selected_source_multichannelaudio',
-  SelectedSourceGPIO = 'selected_source_gpio',
-  SelectedTargetVideo = 'selected_target_video',
-  SelectedTargetAudio = 'selected_target_audio',
-  SelectedTargetData = 'selected_target_data',
-  SelectedTargetMultiChannelAudio = 'selected_target_multichannelaudio',
-  SelectedTargetGPIO = 'selected_target_gpio',
-  TakeTallySourceVideo = 'take_tally_source_video',
-  TakeTallySourceAudio = 'take_tally_source_audio',
-  TakeTallySourceData = 'take_tally_source_data',
-  TakeTallySourceMultiChannelAudio = 'take_tally_source_multichannelaudio',
-  TakeTallySourceGPIO = 'take_tally_source_gpio',
-  RoutingTallyVideo = 'routing_tally_video',
-  RoutingTallyAudio = 'routing_tally_audio',
-  RoutingTallyData = 'routing_tally_data',
-  RoutingTallyMultiChannelAudio = 'routing_tally_multichannelaudio',
-  RoutingTallyGPIO = 'routing_tally_gpio',
+  SelectedSource = 'selected_source',
+  SelectedTarget = 'selected_target',
+  TakeTallySource = 'take_tally_source',
+  RoutingTally = 'routing_tally',
+  SelectedMatrix = 'selected_matrix',
 }
 
 /**
@@ -47,7 +32,7 @@ export function GetFeedbacksList(
   _emberClient: EmberClient,
   state: DeviceState
 ): CompanionFeedbackDefinitions {
-  const { inputChoices, outputChoices } = getInputChoices(state)
+  const { inputChoices, outputChoices, matrixChoices } = getChoices(state)
   const feedbacks: { [id in FeedbackId]: CompanionFeedbackDefinition | undefined } = {
     [FeedbackId.Take]: {
       name: 'Take is possible',
@@ -69,7 +54,7 @@ export function GetFeedbacksList(
     },
     [FeedbackId.Clear]: {
       name: 'Clear is possible',
-      description: 'Changes when a selection is made.',
+      description: 'Returns true when a matrix, source or target is selected.',
       type: 'boolean',
       defaultStyle: {
         bgcolor: combineRgb(255, 255, 255),
@@ -81,7 +66,7 @@ export function GetFeedbacksList(
       }
     },
     [FeedbackId.Undo]: {
-      name: 'True if undo possible',
+      name: 'Undo is possible',
       description: 'Changes Style if undo is possible on current target',
       type: 'boolean',
       defaultStyle: {
@@ -96,9 +81,9 @@ export function GetFeedbacksList(
         } else return false
       }
     },
-    [FeedbackId.SelectedSourceVideo]: {
-      name: 'Video Source Background If Selected',
-      description: 'Change Background of Source, when it is currently selected.',
+    [FeedbackId.SelectedSource]: {
+      name: 'Source Selected',
+      description: 'Returns true when the picked source is currently selected.',
       type: 'boolean',
       defaultStyle: {
         // The default style change for a boolean feedback
@@ -109,435 +94,79 @@ export function GetFeedbacksList(
       options: [
         {
           type: 'dropdown',
-          label: 'Value',
-          id: 'source',
+          label: 'Matrix',
+          id: 'matrix',
           default: 0,
           minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.video]
-        }
-      ],
-      callback: (feedback) => {
-        return state.selected.source == feedback.options['source'] && state.selected.matrix == matrixnames.video
-      }
-    },
-    [FeedbackId.SelectedSourceAudio]: {
-      name: 'Audio Source Background If Selected',
-      description: 'Change Background of Source, when it is currently selected.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.audio]
-        }
-      ],
-      callback: (feedback) => {
-        return state.selected.source == feedback.options['source'] && state.selected.matrix == matrixnames.audio
-      }
-    },
-    [FeedbackId.SelectedSourceData]: {
-      name: 'Data Source Background If Selected',
-      description: 'Change Background of Source, when it is currently selected.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.data]
-        }
-      ],
-      callback: (feedback) => {
-        return state.selected.source == feedback.options['source'] && state.selected.matrix == matrixnames.data
-      }
-    },
-    [FeedbackId.SelectedSourceMultiChannelAudio]: {
-      name: 'MChAudio Source Background If Selected',
-      description: 'Change Background of Source, when it is currently selected.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.multichannelaudio]
-        }
-      ],
-      callback: (feedback) => {
-        return (
-          state.selected.source == feedback.options['source'] && state.selected.matrix == matrixnames.multichannelaudio
-        )
-      }
-    },
-    [FeedbackId.SelectedSourceGPIO]: {
-      name: 'GPI Source Background If Selected',
-      description: 'Change Background of Source, when it is currently selected.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.gpio]
-        }
-      ],
-      callback: (feedback) => {
-        return state.selected.source == feedback.options['source'] && state.selected.matrix == matrixnames.gpio
-      }
-    },
-    [FeedbackId.SelectedTargetVideo]: {
-      name: 'Video Target Background if Selected',
-      description: 'Change Background of Target, when it is currently selected.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'target',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.video]
-        }
-      ],
-      callback: (feedback) => {
-        return state.selected.target == feedback.options['target'] && state.selected.matrix == matrixnames.video
-      }
-    },
-    [FeedbackId.SelectedTargetAudio]: {
-      name: 'Audio Target Background if Selected',
-      description: 'Change Background of Target, when it is currently selected.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'target',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.audio]
-        }
-      ],
-      callback: (feedback) => {
-        return state.selected.target == feedback.options['target'] && state.selected.matrix == matrixnames.audio
-      }
-    },
-    [FeedbackId.SelectedTargetData]: {
-      name: 'Data Target Background if Selected',
-      description: 'Change Background of Target, when it is currently selected.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'target',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.data]
-        }
-      ],
-      callback: (feedback) => {
-        return state.selected.target == feedback.options['target'] && state.selected.matrix == matrixnames.data
-      }
-    },
-    [FeedbackId.SelectedTargetMultiChannelAudio]: {
-      name: 'MChAudio Target Background if Selected',
-      description: 'Change Background of Target, when it is currently selected.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'target',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.multichannelaudio]
-        }
-      ],
-      callback: (feedback) => {
-        return (
-          state.selected.target == feedback.options['target'] && state.selected.matrix == matrixnames.multichannelaudio
-        )
-      }
-    },
-    [FeedbackId.SelectedTargetGPIO]: {
-      name: 'GPO Target Background if Selected',
-      description: 'Change Background of Target, when it is currently selected.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'target',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.gpio]
-        }
-      ],
-      callback: (feedback) => {
-        return state.selected.target == feedback.options['target'] && state.selected.matrix == matrixnames.gpio
-      }
-    },
-    [FeedbackId.TakeTallySourceVideo]: {
-      name: 'Video Source Background if routed on selected Target',
-      description: 'Change Background of Source, when it is currently routed on the selected target.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.video]
-        }
-      ],
-      callback: (feedback) => {
-        if (
-          state.selected.matrix !== matrixnames.video ||
-          state.matrices[state.selected.matrix].outputs == undefined ||
-          state.matrices[state.selected.matrix].outputs.get(state.selected.target) == undefined ||
-          state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route == undefined
-        )
-          return false
-        return feedback.options['source'] == state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route
-      }
-    },
-    [FeedbackId.TakeTallySourceAudio]: {
-      name: 'Audio Source Background if routed on selected Target',
-      description: 'Change Background of Source, when it is currently routed on the selected target.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.audio]
-        }
-      ],
-      callback: (feedback) => {
-        if (
-          state.selected.matrix !== matrixnames.audio ||
-          state.matrices[state.selected.matrix].outputs == undefined ||
-          state.matrices[state.selected.matrix].outputs.get(state.selected.target) == undefined ||
-          state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route == undefined
-        )
-          return false
-        return feedback.options['source'] == state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route
-      }
-    },
-    [FeedbackId.TakeTallySourceData]: {
-      name: 'Data Source Background if routed on selected Target',
-      description: 'Change Background of Source, when it is currently routed on the selected target.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.data]
-        }
-      ],
-      callback: (feedback) => {
-        if (
-          state.selected.matrix !== matrixnames.data ||
-          state.matrices[state.selected.matrix].outputs == undefined ||
-          state.matrices[state.selected.matrix].outputs.get(state.selected.target) == undefined ||
-          state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route == undefined
-        )
-          return false
-        return feedback.options['source'] == state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route
-      }
-    },
-    [FeedbackId.TakeTallySourceMultiChannelAudio]: {
-      name: 'MChAudio Source Background if routed on selected Target',
-      description: 'Change Background of Source, when it is currently routed on the selected target.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.multichannelaudio]
-        }
-      ],
-      callback: (feedback) => {
-        if (
-          state.selected.matrix !== matrixnames.multichannelaudio ||
-          state.matrices[state.selected.matrix].outputs == undefined ||
-          state.matrices[state.selected.matrix].outputs.get(state.selected.target) == undefined ||
-          state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route == undefined
-        )
-          return false
-        return feedback.options['source'] == state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route
-      }
-    },
-    [FeedbackId.TakeTallySourceGPIO]: {
-      name: 'GPI Source Background if routed on selected Target',
-      description: 'Change Background of Source, when it is currently routed on the selected target.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Value',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.gpio]
-        }
-      ],
-      callback: (feedback) => {
-        if (
-          state.selected.matrix !== matrixnames.gpio ||
-          state.matrices[state.selected.matrix].outputs == undefined ||
-          state.matrices[state.selected.matrix].outputs.get(state.selected.target) == undefined ||
-          state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route == undefined
-        )
-          return false
-        return feedback.options['source'] == state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route
-      }
-    },
-    [FeedbackId.RoutingTallyVideo]: {
-      name: 'Video Source is routed to specific target.',
-      description: 'Change Background of Button, when it is currently routed to a specified target.',
-      type: 'boolean',
-      defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
-      },
-      options: [
-        {
-          type: 'dropdown',
-          label: 'Source',
-          id: 'source',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.video]
+          choices: matrixChoices
         },
         {
           type: 'dropdown',
-          label: 'Target',
-          id: 'target',
+          label: `${state.matrices[matrixnames.video].label} Source`,
+          id: `source_${matrixnames.video}`,
           default: 0,
           minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.video]
-        }
-      ],
-      callback: (feedback) => {
-          let target_id = Number(feedback.options['target'])
-          if (state.matrices[matrixnames.video].outputs == undefined ||
-            state.matrices[matrixnames.video].outputs.get(target_id) == undefined ||
-            state.matrices[matrixnames.video].outputs.get(target_id)?.route == undefined) {
-            return false
-          } else {
-            return feedback.options['source'] == state.matrices[matrixnames.video].outputs.get(target_id)?.route
+          choices: inputChoices[matrixnames.video],
+          isVisible: (options) => {
+            return (options['matrix'] == 0)
           }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.audio].label} Source`,
+          id: `source_${matrixnames.audio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.audio],
+          isVisible: options => {
+            return (options['matrix'] == 1)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.data].label} Source`,
+          id: `source_${matrixnames.data}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.data],
+          isVisible: options => {
+            return (options['matrix'] == 2)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.multichannelaudio].label} Source`,
+          id: `source_${matrixnames.multichannelaudio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.multichannelaudio],
+          isVisible: options => {
+            return (options['matrix'] == 3)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.gpio].label} Source`,
+          id: `source_${matrixnames.gpio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.gpio],
+          isVisible: options => {
+            return (options['matrix'] == 4)
+          }
+        }
+      ],
+      callback: (feedback) => {
+        let matrix = Number(feedback.options['matrix'])
+        let source = Number(feedback.options[`source_${matrix}`])
+        if (!Number.isNaN(matrix) && !Number.isNaN(source)) {
+          return state.selected.source == source && state.selected.matrix == matrix
+        } else return false
       }
     },
-
-    [FeedbackId.RoutingTallyAudio]: {
-      name: 'Audio Source is routed to specific target.',
-      description: 'Change Background of Button, when it is currently routed to a specified target.',
+    [FeedbackId.SelectedTarget]: {
+      name: 'Target Selected',
+      description: 'Returns true when the picked target is currently selected.',
       type: 'boolean',
       defaultStyle: {
         // The default style change for a boolean feedback
@@ -548,35 +177,79 @@ export function GetFeedbacksList(
       options: [
         {
           type: 'dropdown',
-          label: 'Source',
-          id: 'source',
+          label: 'Matrix',
+          id: 'matrix',
           default: 0,
           minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.audio]
+          choices: matrixChoices
         },
         {
           type: 'dropdown',
-          label: 'Target',
-          id: 'target',
+          label: `${state.matrices[matrixnames.video].label} Target`,
+          id: `target_${matrixnames.video}`,
           default: 0,
           minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.audio]
+          choices: outputChoices[matrixnames.video],
+          isVisible: (options) => {
+            return (options['matrix'] == 0)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.audio].label} Target`,
+          id: `target_${matrixnames.audio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.audio],
+          isVisible: options => {
+            return (options['matrix'] == 1)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.data].label} Target`,
+          id: `target_${matrixnames.data}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.data],
+          isVisible: options => {
+            return (options['matrix'] == 2)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.multichannelaudio].label} Target`,
+          id: `target_${matrixnames.multichannelaudio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.multichannelaudio],
+          isVisible: options => {
+            return (options['matrix'] == 3)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.gpio].label} Target`,
+          id: `target_${matrixnames.gpio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.gpio],
+          isVisible: options => {
+            return (options['matrix'] == 4)
+          }
         }
       ],
       callback: (feedback) => {
-        let target_id = Number(feedback.options['target'])
-        if (state.matrices[matrixnames.audio].outputs == undefined ||
-          state.matrices[matrixnames.audio].outputs.get(target_id) == undefined ||
-          state.matrices[matrixnames.audio].outputs.get(target_id)?.route == undefined) {
-          return false
-        } else {
-          return feedback.options['source'] == state.matrices[matrixnames.audio].outputs.get(target_id)?.route
-        }
+        let matrix = Number(feedback.options['matrix'])
+        let target = Number(feedback.options[`target_${matrix}`])
+        if (!Number.isNaN(matrix) && !Number.isNaN(target)) {
+          return state.selected.target == target && state.selected.matrix == matrix
+        } else return false
       }
     },
-    [FeedbackId.RoutingTallyData]: {
-      name: 'Data Source is routed to specific target.',
-      description: 'Change Background of Button, when it is currently routed to a specified target.',
+    [FeedbackId.TakeTallySource]: {
+      name: 'Source routed on selected target',
+      description: 'Returns true, when the picked source is the one currently routed to the selected target.',
       type: 'boolean',
       defaultStyle: {
         // The default style change for a boolean feedback
@@ -587,36 +260,83 @@ export function GetFeedbacksList(
       options: [
         {
           type: 'dropdown',
-          label: 'Source',
-          id: 'source',
+          label: 'Matrix',
+          id: 'matrix',
           default: 0,
           minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.data]
+          choices: matrixChoices
         },
         {
           type: 'dropdown',
-          label: 'Target',
-          id: 'target',
+          label: `${state.matrices[matrixnames.video].label} Source`,
+          id: `source_${matrixnames.video}`,
           default: 0,
           minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.data]
+          choices: inputChoices[matrixnames.video],
+          isVisible: (options) => {
+            return (options['matrix'] == 0)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.audio].label} Source`,
+          id: `source_${matrixnames.audio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.audio],
+          isVisible: options => {
+            return (options['matrix'] == 1)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.data].label} Source`,
+          id: `source_${matrixnames.data}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.data],
+          isVisible: options => {
+            return (options['matrix'] == 2)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.multichannelaudio].label} Source`,
+          id: `source_${matrixnames.multichannelaudio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.multichannelaudio],
+          isVisible: options => {
+            return (options['matrix'] == 3)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.gpio].label} Source`,
+          id: `source_${matrixnames.gpio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.gpio],
+          isVisible: options => {
+            return (options['matrix'] == 4)
+          }
         }
       ],
       callback: (feedback) => {
-        let target_id = Number(feedback.options['target'])
-        if (state.matrices[matrixnames.data].outputs == undefined ||
-          state.matrices[matrixnames.data].outputs.get(target_id) == undefined ||
-          state.matrices[matrixnames.data].outputs.get(target_id)?.route == undefined) {
-          return false
-        } else {
-          return feedback.options['source'] == state.matrices[matrixnames.data].outputs.get(target_id)?.route
-        }
+        let matrix = Number(feedback.options['matrix'])
+        let source = Number(feedback.options[`source_${matrix}`])
+        if (Number.isNaN(matrix) && Number.isNaN(source) && (
+          state.selected.matrix !== matrix ||
+          state.matrices[state.selected.matrix].outputs == undefined ||
+          state.matrices[state.selected.matrix].outputs.get(state.selected.target) == undefined ||
+          state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route == undefined)
+        )return false
+        return source == state.matrices[state.selected.matrix].outputs.get(state.selected.target)?.route
       }
     },
-
-    [FeedbackId.RoutingTallyMultiChannelAudio]: {
-      name: 'MultiChannelAudio Source is routed to specific target.',
-      description: 'Change Background of Button, when it is currently routed to a specified target.',
+    [FeedbackId.RoutingTally]: {
+      name: 'Crosspoint Signal',
+      description: 'Returns true, when a picked source is routed on a picked target. Shows if crosspoint is set.',
       type: 'boolean',
       defaultStyle: {
         // The default style change for a boolean feedback
@@ -627,70 +347,159 @@ export function GetFeedbacksList(
       options: [
         {
           type: 'dropdown',
-          label: 'Source',
-          id: 'source',
+          label: 'Matrix',
+          id: 'matrix',
           default: 0,
           minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.multichannelaudio]
+          choices: matrixChoices
         },
         {
           type: 'dropdown',
-          label: 'Target',
-          id: 'target',
+          label: `${state.matrices[matrixnames.video].label} Source`,
+          id: `source_${matrixnames.video}`,
           default: 0,
           minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.multichannelaudio]
+          choices: inputChoices[matrixnames.video],
+          isVisible: (options) => {
+            return (options['matrix'] == 0)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.audio].label} Source`,
+          id: `source_${matrixnames.audio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.audio],
+          isVisible: options => {
+            return (options['matrix'] == 1)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.data].label} Source`,
+          id: `source_${matrixnames.data}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.data],
+          isVisible: options => {
+            return (options['matrix'] == 2)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.multichannelaudio].label} Source`,
+          id: `source_${matrixnames.multichannelaudio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.multichannelaudio],
+          isVisible: options => {
+            return (options['matrix'] == 3)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.gpio].label} Source`,
+          id: `source_${matrixnames.gpio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: inputChoices[matrixnames.gpio],
+          isVisible: options => {
+            return (options['matrix'] == 4)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.video].label} Target`,
+          id: `target_${matrixnames.video}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.video],
+          isVisible: (options) => {
+            return (options['matrix'] == 0)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.audio].label} Target`,
+          id: `target_${matrixnames.audio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.audio],
+          isVisible: options => {
+            return (options['matrix'] == 1)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.data].label} Target`,
+          id: `target_${matrixnames.data}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.data],
+          isVisible: options => {
+            return (options['matrix'] == 2)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.multichannelaudio].label} Target`,
+          id: `target_${matrixnames.multichannelaudio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.multichannelaudio],
+          isVisible: options => {
+            return (options['matrix'] == 3)
+          }
+        },
+        {
+          type: 'dropdown',
+          label: `${state.matrices[matrixnames.gpio].label} Target`,
+          id: `target_${matrixnames.gpio}`,
+          default: 0,
+          minChoicesForSearch: 10,
+          choices: outputChoices[matrixnames.gpio],
+          isVisible: options => {
+            return (options['matrix'] == 4)
+          }
         }
       ],
       callback: (feedback) => {
-        let target_id = Number(feedback.options['target'])
-        if (state.matrices[matrixnames.multichannelaudio].outputs == undefined ||
-          state.matrices[matrixnames.multichannelaudio].outputs.get(target_id) == undefined ||
-          state.matrices[matrixnames.multichannelaudio].outputs.get(target_id)?.route == undefined) {
+        let matrix = Number(feedback.options['matrix'])
+        let target = Number(feedback.options[`target_${matrix}`])
+        let source = Number(feedback.options[`source_${matrix}`])
+        if (Number.isNaN(matrix) ||
+          Number.isNaN(target) ||
+          Number.isNaN(source) ||
+          state.matrices[matrix].outputs == undefined ||
+          state.matrices[matrix].outputs.get(target) == undefined ||
+          state.matrices[matrix].outputs.get(target)?.route == undefined) {
           return false
         } else {
-          return feedback.options['source'] == state.matrices[matrixnames.multichannelaudio].outputs.get(target_id)?.route
+          return source == state.matrices[matrix].outputs.get(target)?.route
         }
       }
     },
-
-    [FeedbackId.RoutingTallyGPIO]: {
-      name: 'GPI Source is routed to specific target.',
-      description: 'Change Background of Button, when it is currently routed to a specified target.',
+    [FeedbackId.SelectedMatrix]: {
+      name: 'Selected Matrix',
+      description: 'Returns true when the picked matrix is selected.',
       type: 'boolean',
       defaultStyle: {
-        // The default style change for a boolean feedback
-        // The user will be able to customise these values as well as the fields that will be changed
-        bgcolor: combineRgb(255, 0, 0),
-        color: combineRgb(0, 0, 0)
+        bgcolor: combineRgb(0, 0, 255),
+        color: combineRgb(255, 255, 255)
       },
       options: [
         {
           type: 'dropdown',
-          label: 'Source',
-          id: 'source',
+          label: 'Matrix',
+          id: 'matrix',
           default: 0,
           minChoicesForSearch: 10,
-          choices: inputChoices[matrixnames.gpio]
-        },
-        {
-          type: 'dropdown',
-          label: 'Target',
-          id: 'target',
-          default: 0,
-          minChoicesForSearch: 10,
-          choices: outputChoices[matrixnames.gpio]
+          choices: matrixChoices,
         }
       ],
       callback: (feedback) => {
-        let target_id = Number(feedback.options['target'])
-        if (state.matrices[matrixnames.gpio].outputs == undefined ||
-          state.matrices[matrixnames.gpio].outputs.get(target_id) == undefined ||
-          state.matrices[matrixnames.gpio].outputs.get(target_id)?.route == undefined) {
-          return false
-        } else {
-          return feedback.options['source'] == state.matrices[matrixnames.gpio].outputs.get(target_id)?.route
-        }
+        return state.selected.matrix == Number(feedback.options['matrix'])
       }
     },
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 import { InstanceBase, InstanceStatus, runEntrypoint, SomeCompanionConfigField } from '@companion-module/base'
 import { GetActionsList } from './actions'
 import { GetConfigFields, DeviceConfig } from './config'
-import { GetFeedbacksList } from './feedback'
+import { FeedbackId, GetFeedbacksList } from './feedback'
 import { DeviceState } from './state'
 import { initVariables } from './variables'
 import { GetPresetsList } from './presets'
 import { EmberClient } from 'node-emberplus/lib/client/ember-client'
+import { getUpgrades } from './upgrades.js'
 
 /**
  * Companion instance class for Riedels Mediornet Devices
@@ -63,6 +64,7 @@ export class MediornetInstance extends InstanceBase<DeviceConfig> {
     this.setFeedbackDefinitions(GetFeedbacksList(this, this.emberClient, this.state))
     this.setPresetDefinitions(GetPresetsList(this.state))
     initVariables(this, this.state)
+    this.checkFeedbacks(FeedbackId.RoutingTally)
   } // end updateCompanionBits
 
   /**
@@ -141,4 +143,4 @@ export class MediornetInstance extends InstanceBase<DeviceConfig> {
   }
 }
 
-runEntrypoint(MediornetInstance, [])
+runEntrypoint(MediornetInstance, getUpgrades())

--- a/src/state.ts
+++ b/src/state.ts
@@ -25,6 +25,7 @@ const gpioPath = '1.2.4.3'
 export interface Matrix {
   id: number
   label: string
+  variableName: string
   path: string
   inputs: Map<number, InputState>
   outputs: Map<number, OutputState>
@@ -66,11 +67,11 @@ export class DeviceState {
       matrix: -1
     }
     this.matrices = [
-      { id: 0, label: 'video', path: videoPath, inputs: new Map(), outputs: new Map() , inputList : [], outputList : []},
-      { id: 1, label: 'audio', path: audioPath, inputs: new Map(), outputs: new Map() , inputList : [], outputList : []},
-      { id: 2, label: 'data', path: dataPath, inputs: new Map(), outputs: new Map() , inputList : [], outputList : []},
-      { id: 3, label: 'multichannelaudio', path: multiChannelAudioPath, inputs: new Map(), outputs: new Map() , inputList : [], outputList : []},
-      { id: 4, label: 'gpio', path: gpioPath, inputs: new Map(), outputs: new Map() , inputList : [], outputList : []}
+      { id: 0, label: 'Video', variableName: 'video', path: videoPath, inputs: new Map(), outputs: new Map() , inputList : [], outputList : []},
+      { id: 1, label: 'Audio',  variableName: 'audio', path: audioPath, inputs: new Map(), outputs: new Map() , inputList : [], outputList : []},
+      { id: 2, label: 'Data', variableName: 'data', path: dataPath, inputs: new Map(), outputs: new Map() , inputList : [], outputList : []},
+      { id: 3, label: 'Multi Channel Audio', variableName: 'multichannelaudio', path: multiChannelAudioPath, inputs: new Map(), outputs: new Map() , inputList : [], outputList : []},
+      { id: 4, label: 'GPIO', variableName: 'gpio', path: gpioPath, inputs: new Map(), outputs: new Map() , inputList : [], outputList : []}
     ]
   }
 
@@ -190,7 +191,7 @@ export class DeviceState {
             if (typeof value.identifier == 'string' && typeof value.value == 'string' && labelTarget != undefined) {
               labelTarget.name = value.identifier
               labelTarget.label = value.value
-              variableValues[`${labelTargetGroup}_${this.matrices[matrix_index].label}_${numKey + 1}`] =
+              variableValues[`${labelTargetGroup}_${this.matrices[matrix_index].variableName}_${numKey + 1}`] =
                 labelTarget.label
             }
 
@@ -200,13 +201,13 @@ export class DeviceState {
                 if (labelTarget != undefined) {
                   labelTarget.label = update.value as string
                   const variableValuesnew: CompanionVariableValues = {}
-                  variableValuesnew[`${labelTargetGroup}_${this.matrices[matrix_index].label}_${numKey + 1}`] =
+                  variableValuesnew[`${labelTargetGroup}_${this.matrices[matrix_index].variableName}_${numKey + 1}`] =
                     labelTarget.label
                   if (labelTargetGroup == 'input') {
                     this.matrices[matrix_index].outputs.forEach((value, key) => {
                       if (value.route == numKey) {
                         console.log(value)
-                        variableValuesnew[`output_${this.matrices[matrix_index].label}_${key + 1}_input`] =
+                        variableValuesnew[`output_${this.matrices[matrix_index].variableName}_${key + 1}_input`] =
                           labelTarget?.label ?? '?'
                       }
                     })
@@ -299,21 +300,13 @@ export class DeviceState {
                     matrixElement.route = sources[0]
                     matrixElement.fallback.push(sources[0])
                     this.self.checkFeedbacks(
-                      FeedbackId.TakeTallySourceVideo,
-                      FeedbackId.TakeTallySourceAudio,
-                      FeedbackId.TakeTallySourceData,
-                      FeedbackId.TakeTallySourceGPIO,
-                      FeedbackId.TakeTallySourceMultiChannelAudio,
-                      FeedbackId.RoutingTallyVideo,
-                      FeedbackId.RoutingTallyAudio,
-                      FeedbackId.RoutingTallyData,
-                      FeedbackId.RoutingTallyMultiChannelAudio,
-                      FeedbackId.RoutingTallyGPIO,
+                      FeedbackId.TakeTallySource,
+                      FeedbackId.RoutingTally,
                       FeedbackId.Take,
                       FeedbackId.Undo
                     )
                     const variableValuesnew: CompanionVariableValues = {}
-                    variableValuesnew[`output_${this.matrices[i].label}_${Number(connectionsKey) + 1}_input`] =
+                    variableValuesnew[`output_${this.matrices[i].variableName}_${Number(connectionsKey) + 1}_input`] =
                       this.getInput(sources[0], i)?.label ?? '?'
                     this.self.setVariableValues(variableValuesnew)
                   } // if sources != undefined

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,0 +1,211 @@
+import { CompanionStaticUpgradeResult, CompanionStaticUpgradeScript } from '@companion-module/base'
+import { DeviceConfig } from './config'
+import { matrixnames } from './state'
+
+
+const upgradeV1_1_4: CompanionStaticUpgradeScript<DeviceConfig> = (_context, props): CompanionStaticUpgradeResult<DeviceConfig> => {
+  let config: any = props.config
+  let actions: any = props.actions
+  let feedbacks: any = props.feedbacks
+
+  const changes: CompanionStaticUpgradeResult<DeviceConfig> = {
+    updatedConfig: config,
+    updatedActions: [],
+    updatedFeedbacks: []
+  }
+
+  // Actions
+  actions.map((action: any) => {
+    if (action.options.target === 'next' || action.options.target === 'previous') {
+      action.options.next_previous_action = true
+      action.options.next_previous = action.options.target
+      delete action.options.target
+    } else if (action.options.source === 'next' || action.options.source === 'previous') {
+      action.options.next_previous_action = true
+      action.options.next_previous = action.options.source
+      delete action.options.source
+    } else {
+      action.options.next_previous_action = false
+    }
+
+    if (action.actionId === 'select_target_video') {
+      action.actionId = 'select_target'
+      action.options.matrix = matrixnames.video
+      action.options.target_0 = action.options.target
+      delete action.options.target
+    } else if (action.actionId === 'select_target_audio') {
+      action.actionId = 'select_target'
+      action.options.matrix = matrixnames.audio
+      action.options.target_1 = action.options.target
+      delete action.options.target
+    } else if (action.actionId === 'select_target_data') {
+      action.actionId = 'select_target'
+      action.options.matrix = matrixnames.data
+      action.options.target_2 = action.options.target
+      delete action.options.target
+    } else if (action.actionId === 'select_target_multichannelaudio') {
+      action.actionId = 'select_target'
+      action.options.matrix = matrixnames.multichannelaudio
+      action.options.target_3 = action.options.target
+      delete action.options.target
+    } else if (action.actionId === 'select_target_gpio') {
+      action.actionId = 'select_target'
+      action.options.matrix = matrixnames.gpio
+      action.options.target_4 = action.options.target
+      delete action.options.target
+    } else if (action.actionId === 'select_source_video') {
+      action.actionId = 'select_source'
+      action.options.matrix = matrixnames.video
+      action.options.source_0 = action.options.source
+      delete action.options.source
+    } else if (action.actionId === 'select_source_audio') {
+      action.actionId = 'select_source'
+      action.options.matrix = matrixnames.audio
+      action.options.source_1 = action.options.source
+      delete action.options.source
+    } else if (action.actionId === 'select_source_data') {
+      action.actionId = 'select_source'
+      action.options.matrix = matrixnames.data
+      action.options.source_2 = action.options.source
+      delete action.options.source
+    } else if (action.actionId === 'select_source_multichannelaudio') {
+      action.actionId = 'select_source'
+      action.options.matrix = matrixnames.multichannelaudio
+      action.options.source_3 = action.options.source
+      delete action.options.source
+    } else if (action.actionId === 'select_source_gpio') {
+      action.actionId = 'select_source'
+      action.options.matrix = matrixnames.gpio
+      action.options.source_4 = action.options.source
+      delete action.options.source
+    }
+    changes.updatedActions.push(action)
+
+    return action
+  })
+
+  // Feedbacks
+  feedbacks.map((feedback: any) => {
+
+    if (feedback.feedbackId === 'selected_source_video') {
+      feedback.feedbackId = 'selected_source'
+      feedback.options.matrix = matrixnames.video
+      feedback.options.source_0 = feedback.options.source
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'selected_source_audio') {
+      feedback.feedbackId = 'selected_source'
+      feedback.options.matrix = matrixnames.audio
+      feedback.options.source_1 = feedback.options.source
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'selected_source_data') {
+      feedback.feedbackId = 'selected_source'
+      feedback.options.matrix = matrixnames.data
+      feedback.options.source_2 = feedback.options.source
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'selected_source_multichannelaudio') {
+      feedback.feedbackId = 'selected_source'
+      feedback.options.matrix = matrixnames.multichannelaudio
+      feedback.options.source_3 = feedback.options.source
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'selected_source_gpio') {
+      feedback.feedbackId = 'selected_source'
+      feedback.options.matrix = matrixnames.gpio
+      feedback.options.source_4 = feedback.options.source
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'selected_target_video') {
+      feedback.feedbackId = 'selected_target'
+      feedback.options.matrix = matrixnames.video
+      feedback.options.target_0 = feedback.options.target
+      delete feedback.options.target
+    } else if (feedback.feedbackId === 'selected_target_audio') {
+      feedback.feedbackId = 'selected_target'
+      feedback.options.matrix = matrixnames.audio
+      feedback.options.target_1 = feedback.options.target
+      delete feedback.options.target
+    } else if (feedback.feedbackId === 'selected_target_data') {
+      feedback.feedbackId = 'selected_target'
+      feedback.options.matrix = matrixnames.data
+      feedback.options.target_2 = feedback.options.target
+      delete feedback.options.target
+    } else if (feedback.feedbackId === 'selected_target_multichannelaudio') {
+      feedback.feedbackId = 'selected_target'
+      feedback.options.matrix = matrixnames.multichannelaudio
+      feedback.options.target_3 = feedback.options.target
+      delete feedback.options.target
+    } else if (feedback.feedbackId === 'selected_target_gpio') {
+      feedback.feedbackId = 'selected_target'
+      feedback.options.matrix = matrixnames.gpio
+      feedback.options.target_4 = feedback.options.target
+      delete feedback.options.target
+    } else if (feedback.feedbackId === 'take_tally_source_video') {
+      feedback.feedbackId = 'take_tally_source'
+      feedback.options.matrix = matrixnames.video
+      feedback.options.source_0 = feedback.options.source
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'take_tally_source_audio') {
+      feedback.feedbackId = 'take_tally_source'
+      feedback.options.matrix = matrixnames.audio
+      feedback.options.source_1 = feedback.options.source
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'take_tally_source_data') {
+      feedback.feedbackId = 'take_tally_source'
+      feedback.options.matrix = matrixnames.data
+      feedback.options.source_2 = feedback.options.source
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'take_tally_source_multichannelaudio') {
+      feedback.feedbackId = 'take_tally_source'
+      feedback.options.matrix = matrixnames.multichannelaudio
+      feedback.options.source_3 = feedback.options.source
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'take_tally_source_gpio') {
+      feedback.feedbackId = 'take_tally_source'
+      feedback.options.matrix = matrixnames.gpio
+      feedback.options.source_4 = feedback.options.source
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'routing_tally_video') {
+      feedback.feedbackId = 'routing_tally'
+      feedback.options.matrix = matrixnames.video
+      feedback.options.source_0 = feedback.options.source
+      feedback.options.target_0 = feedback.options.target
+      delete feedback.options.target
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'routing_tally_audio') {
+      feedback.feedbackId = 'routing_tally'
+      feedback.options.matrix = matrixnames.audio
+      feedback.options.source_1 = feedback.options.source
+      feedback.options.target_1 = feedback.options.target
+      delete feedback.options.target
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'routing_tally_data') {
+      feedback.feedbackId = 'routing_tally'
+      feedback.options.matrix = matrixnames.data
+      feedback.options.source_2 = feedback.options.source
+      feedback.options.target_2 = feedback.options.target
+      delete feedback.options.target
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'routing_tally_multichannelaudio') {
+      feedback.feedbackId = 'routing_tally'
+      feedback.options.matrix = matrixnames.multichannelaudio
+      feedback.options.source_3 = feedback.options.source
+      feedback.options.target_3 = feedback.options.target
+      delete feedback.options.target
+      delete feedback.options.source
+    } else if (feedback.feedbackId === 'routing_tally_gpio') {
+      feedback.feedbackId = 'routing_tally'
+      feedback.options.matrix = matrixnames.gpio
+      feedback.options.source_4 = feedback.options.source
+      feedback.options.target_4 = feedback.options.target
+      delete feedback.options.target
+      delete feedback.options.source
+    }
+    changes.updatedFeedbacks.push(feedback)
+
+    return feedback
+  })
+
+  return changes
+}
+
+export const getUpgrades = (): CompanionStaticUpgradeScript<DeviceConfig>[] => {
+  return [upgradeV1_1_4]
+}

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -3,7 +3,7 @@ import { DeviceConfig } from './config'
 import { matrixnames } from './state'
 
 
-const upgradeV1_1_4: CompanionStaticUpgradeScript<DeviceConfig> = (_context, props): CompanionStaticUpgradeResult<DeviceConfig> => {
+const upgradeV1_2_0: CompanionStaticUpgradeScript<DeviceConfig> = (_context, props): CompanionStaticUpgradeResult<DeviceConfig> => {
   let config: any = props.config
   let actions: any = props.actions
   let feedbacks: any = props.feedbacks
@@ -207,5 +207,5 @@ const upgradeV1_1_4: CompanionStaticUpgradeScript<DeviceConfig> = (_context, pro
 }
 
 export const getUpgrades = (): CompanionStaticUpgradeScript<DeviceConfig>[] => {
-  return [upgradeV1_1_4]
+  return [upgradeV1_2_0]
 }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -16,10 +16,10 @@ export function initVariables(self: InstanceBase<DeviceConfig>, state: DeviceSta
         if (input.active) {
           variableDefinitions.push({
             name: `Label of input ${state.matrices[i].label} ${key + 1}`,
-            variableId: `input_${state.matrices[i].label}_${key + 1}`
+            variableId: `input_${state.matrices[i].variableName}_${key + 1}`
           })
 
-          variableValues[`input_${state.matrices[i].label}_${key + 1}`] = input.label
+          variableValues[`input_${state.matrices[i].variableName}_${key + 1}`] = input.label
         }
       }
     )
@@ -30,17 +30,17 @@ export function initVariables(self: InstanceBase<DeviceConfig>, state: DeviceSta
         if (output.active) {
           variableDefinitions.push({
             name: `Label of output ${state.matrices[i].label} ${key + 1}`,
-            variableId: `output_${state.matrices[i].label}_${key + 1}`
+            variableId: `output_${state.matrices[i].variableName}_${key + 1}`
           })
 
-          variableValues[`output_${state.matrices[i].label}_${key + 1}`] = output.label
+          variableValues[`output_${state.matrices[i].variableName}_${key + 1}`] = output.label
 
           variableDefinitions.push({
             name: `Label of input routed to ${state.matrices[i].label} output ${key + 1}`,
-            variableId: `output_${state.matrices[i].label}_${key + 1}_input`
+            variableId: `output_${state.matrices[i].variableName}_${key + 1}_input`
           })
 
-          variableValues[`output_${state.matrices[i].label}_${key + 1}_input`] =
+          variableValues[`output_${state.matrices[i].variableName}_${key + 1}_input`] =
             state.getInput(output.route, i)?.label ?? '?'
         }
       }


### PR DESCRIPTION
This Version does a massive restructure of actions and feedbacks.

Now you can just have the actions "select_source" and "select_target". In those you can select the wanted matrix and then the corresponding sources and targets. 
The same thing applies to the feedbacks.
There ist also a new "select_matrix" action and a corresponding feedback which is useful for the "previous" and "next" actions on the StreamDeck+.

There is also and category update for the presets and some added descriptions for actions and feedbacks.